### PR TITLE
Wasp telemetry now recognizes it is being run from gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
     env:
       WASP_TELEMETRY_CONTEXT: gitpod
     command: |
-      WASP_TELEMETRY_USER_ID=$GITPOD_WORKSPACE_ID
+      export WASP_TELEMETRY_USER_ID=$GITPOD_WORKSPACE_ID
       cd MyNewApp
       wasp start
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,8 @@ tasks:
       echo "export PATH=$PATH:/home/gitpod/.local/bin" >> ~/.bashrc
       . ~/.bashrc
       curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+    env:
+      WASP_TELEMETRY_CONTEXT: gitpod
     command: |
       cd MyNewApp
       wasp start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,7 @@ tasks:
     env:
       WASP_TELEMETRY_CONTEXT: gitpod
     command: |
+      WASP_TELEMETRY_USER_ID=$GITPOD_WORKSPACE_ID
       cd MyNewApp
       wasp start
 


### PR DESCRIPTION
This will help us do telemetry better with Wasp, since gitpod runs make it harder to figure out repetitive usage, so we want to know which telemetry data is coming from gitpod so we can treat it in different way.

Connected to https://github.com/wasp-lang/wasp/pull/564 .